### PR TITLE
Parser modifications and more tests

### DIFF
--- a/src/Parser.hs
+++ b/src/Parser.hs
@@ -22,7 +22,8 @@ data CDef =
     deriving (Show, Eq)
 
 data Tld = 
-    FuncDef Identifier Identifier Type Exp Type 
+    FuncDefUnary Identifier Identifier Type Exp Type 
+    |   FuncDefNullary Identifier Exp Type
     |   DataDef Identifier [CDef]
     deriving (Show, Eq)
 
@@ -44,7 +45,8 @@ data Exp =
 tld :: Parser Tld
 tld = 
     try dDef 
-    <|> fDef
+    <|> try nullaryFDef
+    <|> unaryFDef
 
 cDef :: Parser CDef
 cDef = 
@@ -84,8 +86,8 @@ dDef = do
     cDefs <- many1 cDef
     return $ DataDef name cDefs
 
-fDef :: Parser Tld
-fDef = do
+unaryFDef :: Parser Tld
+unaryFDef = do
     name <- identifier
     _ <- string "=func("
     paramName <- identifier
@@ -96,7 +98,17 @@ fDef = do
     _ <- char '{'
     body <- exp'
     _ <- char '}'
-    return $ FuncDef name paramName paramType body retType
+    return $ FuncDefUnary name paramName paramType body retType
+
+nullaryFDef :: Parser Tld
+nullaryFDef = do
+    name <- identifier
+    _ <- string "=func():"
+    retType <- Type <$> identifier
+    _ <- char '{'
+    body <- exp'
+    _ <- char '}'
+    return $ FuncDefNullary name body retType
 
 expAtom :: Parser Exp
 expAtom =   
@@ -176,6 +188,6 @@ identifier = do
 removeSpaces :: String -> String
 removeSpaces = filter (/=' ')
 
-parseInput input = parse (many fDef) "failed" (removeSpaces input)
+parseInput input = parse (many unaryFDef) "failed" (removeSpaces input)
 
 parse' parser input = parse parser "failed" input

--- a/src/Parser.hs
+++ b/src/Parser.hs
@@ -39,7 +39,8 @@ data Exp =
     |   ExpString String
     |   ExpIExp IExp
     |   ExpLambda Exp Exp Type
-    |   ExpFOCall Identifier Exp
+    |   ExpUnaryFOCall Identifier Exp
+    |   ExpNullaryFOCall Identifier
     deriving (Show, Eq)
 
 tld :: Parser Tld
@@ -55,7 +56,8 @@ cDef =
 
 exp' :: Parser Exp
 exp' = 
-    try fOCall
+    try unaryFOCall
+    <|> try nullaryFOCall
     <|> try lambda
     <|> ExpIExp <$> (try iExp')
     <|> expAtom
@@ -126,13 +128,19 @@ lambda = do
     retType <- identifier 
     return $ ExpLambda parameter body (Type retType)
 
-fOCall :: Parser Exp
-fOCall = do
+unaryFOCall :: Parser Exp
+unaryFOCall = do
     fName <- identifier
     _ <- char '('
     parameter <- expAtom
     _ <- char ')'
-    return $ ExpFOCall fName parameter
+    return $ ExpUnaryFOCall fName parameter
+
+nullaryFOCall :: Parser Exp
+nullaryFOCall = do
+    fName <- identifier
+    _ <- string "()"
+    return $ ExpNullaryFOCall fName
 
 iBinOp :: Parser IBinOp
 iBinOp =    

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -41,6 +41,6 @@ spec = do
         it "parses tlds" $ do
             parseTld "datanewType=Nullary" `shouldBe` (Right (DataDef (Identifier "newType") [NullaryConstructor $ Identifier "Nullary"]))
             -- unresolved bug with multiple constructors
-            parseTld "funk=func(a:string):string{a}" `shouldBe` (Right (FuncDef (Identifier "funk") (Identifier "a") (Type $ Identifier "string") (ExpVariable $ Identifier "a") (Type $ Identifier "string")))
-            -- parseTld "funk=func():string{a}" `shouldBe` (Right (FuncDef (Identifier "funk") (ExpVariable $ Identifier "a") (Type $ Identifier "string")))
+            parseTld "funk=func(a:string):string{a}" `shouldBe` (Right (FuncDefUnary (Identifier "funk") (Identifier "a") (Type $ Identifier "string") (ExpVariable $ Identifier "a") (Type $ Identifier "string")))
+            parseTld "funk=func():string{a}" `shouldBe` (Right (FuncDefNullary (Identifier "funk") (ExpVariable $ Identifier "a") (Type $ Identifier "string")))
 

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -35,11 +35,13 @@ spec = do
             parseExp "\"xyz\"" `shouldBe` (Right $ ExpString "xyz")
             parseExp "\\(x){x}:String" `shouldBe` (Right (ExpLambda (ExpVariable $ Identifier "x") (ExpVariable $ Identifier "x") (Type $ Identifier "String")))
             parseExp "name(x)" `shouldBe` (Right (ExpFOCall (Identifier "name") (ExpVariable $ Identifier "x")))
+            parseExp "x*y" `shouldBe` (Right $ ExpIExp $ IExp (IExpVar $ Identifier "x") Mult (IExpVar $ Identifier "y"))
             -- parseExp "name()" `shouldBe` (Right (ExpFOCall (Identifier "name") (ExpVariable $ Identifier "x")))
 
     describe "top level function and data definitions" $ do
         it "parses tlds" $ do
             parseTld "datanewType=Nullary" `shouldBe` (Right (DataDef (Identifier "newType") [NullaryConstructor $ Identifier "Nullary"]))
+            parseTld "datanewType=Calculate(Integer)" `shouldBe` (Right (DataDef (Identifier "newType") [UnaryConstructor (Identifier "Calculate") (Type $ Identifier "Integer")]))
             -- unresolved bug with multiple constructors
             parseTld "funk=func(a:string):string{a}" `shouldBe` (Right (FuncDefUnary (Identifier "funk") (Identifier "a") (Type $ Identifier "string") (ExpVariable $ Identifier "a") (Type $ Identifier "string")))
             parseTld "funk=func():string{a}" `shouldBe` (Right (FuncDefNullary (Identifier "funk") (ExpVariable $ Identifier "a") (Type $ Identifier "string")))

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -22,7 +22,6 @@ spec = do
             parseIExp "2^y" `shouldBe` (Right $ IExp (IExpInt 2) Exponent (IExpVar $ Identifier "y"))
             -- parseIExp "\02^y" `shouldBe` (Left "failed" Message)
 
-            -- parseIExp "x/0" `shouldBe` (Right $ IExp (IExpVar $ Identifier "x") Div (IExpInt 0)) -- should be changed to error later
             -- parseIExp "2*x+y" `shouldBe` (Right $ IExp (IExp (IExpInt 2) Mult (IExpVar $ Identifier "x")) Plus (IExpVar $ Identifier "y"))
 
             -- "x*y==z" unresolved bug with recursive integer expressions

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -15,6 +15,16 @@ spec = do
             parseIExp "1+1" `shouldBe` (Right $ IExp (IExpInt 1) Plus (IExpInt 1))
             parseIExp "x-1" `shouldBe` (Right $ IExp (IExpVar $ Identifier "x") Minus (IExpInt 1))
             parseIExp "x*y" `shouldBe` (Right $ IExp (IExpVar $ Identifier "x") Mult (IExpVar $ Identifier "y"))
+            parseIExp "x/1" `shouldBe` (Right $ IExp (IExpVar $ Identifier "x") Div (IExpInt 1))
+            parseIExp "x" `shouldBe` (Right $ IExpVar $ Identifier "x")
+            parseIExp "1" `shouldBe` (Right $ IExpInt 1)
+            parseIExp "2==y" `shouldBe` (Right $ IExp (IExpInt 2) Equals (IExpVar $ Identifier "y"))
+            parseIExp "2^y" `shouldBe` (Right $ IExp (IExpInt 2) Exponent (IExpVar $ Identifier "y"))
+            -- parseIExp "\02^y" `shouldBe` (Left "failed" Message)
+
+            -- parseIExp "x/0" `shouldBe` (Right $ IExp (IExpVar $ Identifier "x") Div (IExpInt 0)) -- should be changed to error later
+            -- parseIExp "2*x+y" `shouldBe` (Right $ IExp (IExp (IExpInt 2) Mult (IExpVar $ Identifier "x")) Plus (IExpVar $ Identifier "y"))
+
             -- "x*y==z" unresolved bug with recursive integer expressions
     
     describe "expressions" $ do
@@ -25,9 +35,12 @@ spec = do
             parseExp "\"xyz\"" `shouldBe` (Right $ ExpString "xyz")
             parseExp "\\(x){x}:String" `shouldBe` (Right (ExpLambda (ExpVariable $ Identifier "x") (ExpVariable $ Identifier "x") (Type $ Identifier "String")))
             parseExp "name(x)" `shouldBe` (Right (ExpFOCall (Identifier "name") (ExpVariable $ Identifier "x")))
-    
+            -- parseExp "name()" `shouldBe` (Right (ExpFOCall (Identifier "name") (ExpVariable $ Identifier "x")))
+
     describe "top level function and data definitions" $ do
         it "parses tlds" $ do
             parseTld "datanewType=Nullary" `shouldBe` (Right (DataDef (Identifier "newType") [NullaryConstructor $ Identifier "Nullary"]))
             -- unresolved bug with multiple constructors
             parseTld "funk=func(a:string):string{a}" `shouldBe` (Right (FuncDef (Identifier "funk") (Identifier "a") (Type $ Identifier "string") (ExpVariable $ Identifier "a") (Type $ Identifier "string")))
+            -- parseTld "funk=func():string{a}" `shouldBe` (Right (FuncDef (Identifier "funk") (ExpVariable $ Identifier "a") (Type $ Identifier "string")))
+

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -34,9 +34,9 @@ spec = do
             parseExp "12323232" `shouldBe` (Right $ ExpInteger 12323232)
             parseExp "\"xyz\"" `shouldBe` (Right $ ExpString "xyz")
             parseExp "\\(x){x}:String" `shouldBe` (Right (ExpLambda (ExpVariable $ Identifier "x") (ExpVariable $ Identifier "x") (Type $ Identifier "String")))
-            parseExp "name(x)" `shouldBe` (Right (ExpFOCall (Identifier "name") (ExpVariable $ Identifier "x")))
             parseExp "x*y" `shouldBe` (Right $ ExpIExp $ IExp (IExpVar $ Identifier "x") Mult (IExpVar $ Identifier "y"))
-            -- parseExp "name()" `shouldBe` (Right (ExpFOCall (Identifier "name") (ExpVariable $ Identifier "x")))
+            parseExp "name(x)" `shouldBe` (Right (ExpUnaryFOCall (Identifier "name") (ExpVariable $ Identifier "x")))
+            parseExp "name()" `shouldBe` (Right (ExpNullaryFOCall (Identifier "name")))
 
     describe "top level function and data definitions" $ do
         it "parses tlds" $ do


### PR DESCRIPTION
Modified the parser to separate function definitions and function calls into nullary and unary cases, like cDef. Also added several tests.

- Coverage now achieves 93%. Still doesn't not cover some string operations/filters.